### PR TITLE
allow non-integer channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* fixed issue w/ non-integer channels
+
 ## v1.0.1 - 2017-11-29
 
 * Update golang to 1.9.3 [Will Boyce]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.9.2
 
-ADD *.go /go/src/github.com/wrboyce/plexheadend/
-RUN go get -v github.com/wrboyce/plexheadend
+ADD *.go /go/src/github.com/papaschloss/plexheadend/
+RUN go get -v github.com/papaschloss/plexheadend
 CMD plexheadend

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-USERNAME ?= wrboyce
+USERNAME ?= papaschloss
 PROJECT ?= plexheadend
 EXECUTABLE ?= plexheadend
 DOCKER_IMAGE ?= $(USERNAME)/$(PROJECT)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,18 @@
 # plexheadend
 
-[![GoDoc](https://godoc.org/github.com/wrboyce/plexheadend?status.svg)](https://godoc.org/github.com/wrboyce/plexheadend)
-[![Go Report Card](https://goreportcard.com/badge/github.com/wrboyce/plexheadend)](https://goreportcard.com/report/github.com/wrboyce/plexheadend)
-[![CircleCI](https://circleci.com/gh/wrboyce/plexheadend.png?style=shield)](https://circleci.com/gh/wrboyce/plexheadend)
-
 Proxy requests between PlexDVR and TVHeadend
+
+This fixes an issue in github.com/wrboyce/plexheadend where OTA channels (like "2.1") won't work with plexheadend.
 
 ## Installation
 
-### Binary Release
-
-Download the latest release from the [downloads page](https://github.com/wrboyce/plexheadend/releases).
-
 ### Build from Source
 
-Download and build the project and its dependencies with the standard Go tooling, `go get github.com/wrboyce/plexheadend`.
+Download and build the project and its dependencies with the standard Go tooling, `go get github.com/papaschloss/plexheadend`.
 
 ### Docker Container
 
-There is also a Docker container made available for use at `wrboyce/plexheadend`.
+There is also a Docker container made available for use at `papaschloss/plexheadend`.
 
 ## Usage
 
@@ -69,7 +63,7 @@ services:
         restart: unless-stopped
         
     plexheadend:
-        image: wrboyce/plexheadend
+        image: papaschloss/plexheadend
         container_name: plexheadend
         environment:
             - PLEXHEADEND_TVH_HOST=tvheadend

--- a/plex.go
+++ b/plex.go
@@ -76,7 +76,7 @@ func (p *plexHeadend) lineupHandler(w http.ResponseWriter, r *http.Request) {
 	for _, channel := range p.tvhGetChannels() {
 		if p.tag == "" || sliceContains(channel.Tags, p.tag) {
 			data = append(data,
-				lineupResponse{fmt.Sprintf("%d", channel.Number), channel.Name, channel.URL})
+				lineupResponse{fmt.Sprintf("%s", channel.Number), channel.Name, channel.URL})
 		}
 	}
 	json.NewEncoder(w).Encode(data)

--- a/tvheadenv.go
+++ b/tvheadenv.go
@@ -39,7 +39,7 @@ type apiChannelsResponse struct {
 type apiChannel struct {
 	UUID   string   `json:"uuid"`
 	Name   string   `json:"name"`
-	Number int      `json:"number"`
+	Number string   `json:"number"`
 	Tags   []string `json:"tags"`
 	URL    string   `json:"url"`
 }


### PR DESCRIPTION
My TV tuner doesn't work with plexheadend because the OTA channels are non-integer (like "2.1"). This allows non-integer channels and makes everything work great with Plex.